### PR TITLE
ACTemplateAppDelegate fix

### DIFF
--- a/DVAppCore/Templates/ACTemplateAppDelegate.m
+++ b/DVAppCore/Templates/ACTemplateAppDelegate.m
@@ -73,14 +73,14 @@
 @implementation UIViewController(orientationFix)
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     NSNumber *interfaceOrientationsData = [self ac_interfaceOrientationsData];
-    return interfaceOrientationsData ? interfaceOrientationsData.integerValue : [[self ac_appDelegate] ac_interfaceOrientationsDefault];
-}
-
-- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
-    NSNumber *interfaceOrientationsData = [self ac_interfaceOrientationsData];
-    return [self interfaceOrientationByMask:(interfaceOrientationsData
-                                             ? interfaceOrientationsData.integerValue
-                                             : [[self ac_appDelegate] ac_interfaceOrientationsDefault])];
+    if (interfaceOrientationsData) {
+        return interfaceOrientationsData.integerValue;
+    } else {
+        if ([[self ac_appDelegate] respondsToSelector:@selector(ac_interfaceOrientationsDefault)]) {
+            return [[self ac_appDelegate] ac_interfaceOrientationsDefault];
+        }
+        return UIInterfaceOrientationMaskPortrait;
+    };
 }
 
 - (BOOL)shouldAutorotate {
@@ -93,6 +93,9 @@
 }
 
 - (NSNumber *)ac_interfaceOrientationsData {
+    if (![[self ac_appDelegate] respondsToSelector:@selector(ac_interfaceOrientations)]) {
+        return nil;
+    }
     NSNumber *interfaceOrientationsData = [self ac_appDelegate].ac_interfaceOrientations[NSStringFromClass([self class])];
     
     if (!interfaceOrientationsData) {

--- a/DVAppCore/Templates/ACTemplateAppDelegate.m
+++ b/DVAppCore/Templates/ACTemplateAppDelegate.m
@@ -71,6 +71,7 @@
 
 #pragma mark - UIViewController(ACOrientation)
 @implementation UIViewController(orientationFix)
+
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     NSNumber *interfaceOrientationsData = [self ac_interfaceOrientationsData];
     if (interfaceOrientationsData) {
@@ -81,6 +82,13 @@
         }
         return UIInterfaceOrientationMaskPortrait;
     };
+}
+
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
+    NSNumber *interfaceOrientationsData = [self ac_interfaceOrientationsData];
+    return [self interfaceOrientationByMask:(interfaceOrientationsData
+                                             ? interfaceOrientationsData.integerValue
+                                             : [[self ac_appDelegate] ac_interfaceOrientationsDefault])];
 }
 
 - (BOOL)shouldAutorotate {
@@ -97,14 +105,13 @@
         return nil;
     }
     NSNumber *interfaceOrientationsData = [self ac_appDelegate].ac_interfaceOrientations[NSStringFromClass([self class])];
-    
+
     if (!interfaceOrientationsData) {
         if ([self isKindOfClass:[UINavigationController class]]) {
             UIViewController *visibleVC = ((UINavigationController *)self).visibleViewController;
             interfaceOrientationsData = [self ac_appDelegate].ac_interfaceOrientations[NSStringFromClass([visibleVC class])];
         }
     }
-    
     return interfaceOrientationsData;
 }
 

--- a/DVAppCore/Templates/ACTemplateAppDelegate.m
+++ b/DVAppCore/Templates/ACTemplateAppDelegate.m
@@ -71,7 +71,6 @@
 
 #pragma mark - UIViewController(ACOrientation)
 @implementation UIViewController(orientationFix)
-
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     NSNumber *interfaceOrientationsData = [self ac_interfaceOrientationsData];
     if (interfaceOrientationsData) {
@@ -104,6 +103,7 @@
     if (![[self ac_appDelegate] respondsToSelector:@selector(ac_interfaceOrientations)]) {
         return nil;
     }
+    
     NSNumber *interfaceOrientationsData = [self ac_appDelegate].ac_interfaceOrientations[NSStringFromClass([self class])];
 
     if (!interfaceOrientationsData) {
@@ -112,6 +112,7 @@
             interfaceOrientationsData = [self ac_appDelegate].ac_interfaceOrientations[NSStringFromClass([visibleVC class])];
         }
     }
+
     return interfaceOrientationsData;
 }
 


### PR DESCRIPTION
Negating the effect of UIViewController(orientationFix) if ACTemplateAppDelegate is not used as a parental class for AppDelegate